### PR TITLE
FIX scientific notation appearing inside tweet URL

### DIFF
--- a/_add_ons/bluebird/pi.bluebird.php
+++ b/_add_ons/bluebird/pi.bluebird.php
@@ -4,7 +4,7 @@ class Plugin_bluebird extends Plugin {
 
 	var $meta = array(
 		'name'      	=> 'Blue Bird',
-		'version'    	=> '1.2',
+		'version'    	=> '1.2.1',
 		'author'     	=> 'Nick Snyder',
 		'author_url' 	=> 'http://fasterhorses.co',
 		'contributor'   => 'MikeNGarrett',
@@ -166,7 +166,7 @@ class Plugin_bluebird extends Plugin {
 				}
 
 				$tweet['text'] = $tweetText;
-				$tweet['tweet_url'] = "https://twitter.com/" . $tweet['user']['screen_name'] . "/status/" . $tweet['id'];
+				$tweet['tweet_url'] = "https://twitter.com/" . $tweet['user']['screen_name'] . "/status/" . $tweet['id_str'];
 
 				array_push($output["tweets"], $tweet);
 				array_push($output["user"], $tweet['user']);


### PR DESCRIPTION
We had this strange thing happening on some servers, that the tweet id was treated by PHP like a number, and concatenated in scientific notation when building the URL !
Example :
https://twitter.com/bluebird/status/6.0535463203089E+17
